### PR TITLE
Tidier urls

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,10 +2,10 @@
       <p class="intro">Build your own tools using our API to access GSA Auctions listings</p>
     <nav>    
         <ul>
-          <li><a href="index.html" class="overview">Overview</a></li>
-          <li><a href="basics.html" class="basics">API basics</a></li>
+          <li><a href="http://gsa.github.io/auctions_api/" class="overview">Overview</a></li>
+          <li><a href="basics" class="basics">API basics</a></li>
           <li><a href="console/" class="console">API calls</a></li>
-          <li><a href="fields.html" class="fields">Field reference</a></li>
+          <li><a href="fields" class="fields">Field reference</a></li>
           <li><a href="https://github.com/GSA/Auctions_api/issues" target="_blank" class="fields">Feedback</a></li>
         </ul>
     </nav>

--- a/console/index.html
+++ b/console/index.html
@@ -85,12 +85,12 @@
     <div class="content">
 
     <aside>
-    <h1 class="page-title"><a href="../index.html">GSA Auctions API</a></h1>
+    <h1 class="page-title"><a href="http://gsa.github.io/auctions_api/">GSA Auctions API</a></h1>
       <p class="intro">Build your own tools using our API to access Auction listings <ul>
-          <li><a href="../index.html" class="overview">Overview</a></li>
-          <li><a href="../basics.html" class="basics">API basics</a></li>
+          <li><a href="http://gsa.github.io/auctions_api/" class="overview">Overview</a></li>
+          <li><a href="../basics" class="basics">API basics</a></li>
           <li><a href="../console/" class="console">API calls</a></li>
-          <li><a href="../fields.html" class="fields">Field reference</a></li>
+          <li><a href="../fields" class="fields">Field reference</a></li>
           <li><a href="https://github.com/GSA/GSA-APIs/issues" target="_blank" class="fields">Feedback</a></li>
         </ul>
     </nav>

--- a/index.md
+++ b/index.md
@@ -13,8 +13,8 @@ GSA Auctions API is a public GET API. The Auction listings will be delivered to 
 ##### Get started
 We organized this site into four major areas.
 
-- [API basics](basics.html) introduces you to the operations offered by the API.
+- [API basics](basics) introduces you to the operations offered by the API.
 - [API calls](console/) gives you a hands-on experience of those operations with an interactive console.
-- [Field reference](fields.html) lists and describes the type of information provided by the API.
+- [Field reference](fields) lists and describes the type of information provided by the API.
 - [Feedback](https://github.com/GSA/Auctions_api/issues) provides a forum for developers to share feedback and report problems.
 

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ layout: default
 
 ### Overview
 
-The [GSA Auctions](www.gsaauctions.gov) offers Federal personal property assets ranging from common place items (such as office equipment and furniture) to more select products like scientific equipment, heavy machinery, airplanes, vessels and vehicles. GSA Auctions' online capabilities allow GSA to offer assets located across the country to any interested buyer, regardless of location.
+[GSA Auctions](www.gsaauctions.gov) offers Federal personal property assets ranging from common place items (such as office equipment and furniture) to more select products like scientific equipment, heavy machinery, airplanes, vessels and vehicles. GSA Auctions' online capabilities allow GSA to offer assets located across the country to any interested buyer, regardless of location.
 
 GSA Auctions API is a public GET API. The Auction listings will be delivered to the user in two formats. One is JSON and the other one is XML.  The auction listings delivered thru the API contains the auction listings from all the participating agencies.   
 


### PR DESCRIPTION
mostly focuses on making links like `http://gsa.github.io/auctions_api/basics.html` into 'http://gsa.github.io/auctions_api/basics' just to have cleaner urls 
