### PR TITLE
Change the "registrationSource" of the embedded signup form

### DIFF
--- a/key.md
+++ b/key.md
@@ -8,7 +8,7 @@ nav: basics
 <script type="text/javascript">
   /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
   var apiUmbrellaSignupOptions = {
-    registrationSource: 'web',
+    registrationSource: 'gsa-auctions',
     apiKey: '0aYAx2eY37dkfjqsrrZ53SSCkY1yY2kRYGvY27rv'
   };
 


### PR DESCRIPTION
This is just one little tweak that I forgot about when I was giving you the snippet of code earlier. This changes the `registrationSource` variable in your signup form embed code to `gsa-auctions`. The purpose of this is so we can better identify where our user registrations are coming from. The value can really be anything, we just want an easy identifier to uniquely identify the different web pages where our signup form is being embedded.
