### PR TITLE
Update the example API URL the user sees after signing up

### DIFF
--- a/key.md
+++ b/key.md
@@ -9,7 +9,8 @@ nav: basics
   /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
   var apiUmbrellaSignupOptions = {
     registrationSource: 'gsa-auctions',
-    apiKey: '0aYAx2eY37dkfjqsrrZ53SSCkY1yY2kRYGvY27rv'
+    apiKey: '0aYAx2eY37dkfjqsrrZ53SSCkY1yY2kRYGvY27rv',
+    exampleApiUrl: 'https://api.data.gov/gsa/auctions?api_key={{api_key}}&format=JSON'
   };
 
   /* * * DON'T EDIT BELOW THIS LINE * * */


### PR DESCRIPTION
This will just tweak the signup confirmation page the user sees after signing up for their own API key. The example URL being used will instead be a link to your own API, rather than another random one from api.data.gov.
