### PR TITLE
Fix missing api key in the example URL on the signup confirmation page

### DIFF
--- a/key.md
+++ b/key.md
@@ -4,6 +4,7 @@ title: Request an API Key
 nav: basics
 ---
 
+{% raw %}
 <div id="apidatagov_signup">Loading signup form...</div>
 <script type="text/javascript">
   /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
@@ -21,3 +22,4 @@ nav: basics
   })();
 </script>
 <noscript>Please enable JavaScript to signup for an <a href="http://api.data.gov/">api.data.gov</a> API key.</noscript>
+{% endraw %}


### PR DESCRIPTION
When signing up, I noticed that the user's api key wasn't actually present in example URL given after we made the change in #20. It turns out Jekyll/GitHub pages was gobbling that. Sorry for missing this earlier!

This adds jekyll raw tags to prevent the {{api_key}} from disappearing. Our use of double braces was interfering with what Jekyll and GitHub Pages does.
