### PR TITLE
Fix layout when loading over HTTPS

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,7 +2,7 @@
       <p class="intro">Build your own tools using our API to access GSA Auctions listings</p>
     <nav>    
         <ul>
-          <li><a href="http://gsa.github.io/auctions_api/" class="overview">Overview</a></li>
+          <li><a href="https://gsa.github.io/auctions_api/" class="overview">Overview</a></li>
           <li><a href="basics" class="basics">API basics</a></li>
           <li><a href="fields" class="fields">Field reference</a></li>
           <li><a href="key" class="fields">API Key</a></li>

--- a/_layouts/data_access.html
+++ b/_layouts/data_access.html
@@ -6,15 +6,15 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="chrome=1">
   <title>SAM API documentation - GSA</title>
-  <link rel="stylesheet" href="http://gsa.github.io/auctions_api/static/css/normalize.css">
-  <link rel="stylesheet" href="http://gsa.github.io/auctions_api/static/css/style.css">
+  <link rel="stylesheet" href="https://gsa.github.io/auctions_api/static/css/normalize.css">
+  <link rel="stylesheet" href="https://gsa.github.io/auctions_api/static/css/style.css">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!--[if lt IE 9]>
   <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <!--[if IE]>
-  <link rel="stylesheet" href="http://gsa.github.io/auctions_api/static/css/for-ie-only.css">
+  <link rel="stylesheet" href="https://gsa.github.io/auctions_api/static/css/for-ie-only.css">
   <![endif]-->
 </head>
 <body>
@@ -41,7 +41,7 @@
         {% include footer.html %}
       </div>
     </footer>
-  <script src="http://gsa.github.io/auctions_api/static/js/docs.min.js"></script>
-  <script type="text/javascript" src="http://gsa.github.io/auctions_api/static/js/expandables.js"></script>
+  <script src="https://gsa.github.io/auctions_api/static/js/docs.min.js"></script>
+  <script type="text/javascript" src="https://gsa.github.io/auctions_api/static/js/expandables.js"></script>
 </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,15 +6,15 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="chrome=1">
   <title>Auctions API documentation - GSA</title>
-  <link rel="stylesheet" href="http://gsa.github.io/auctions_api/static/css/normalize.css">
-  <link rel="stylesheet" href="http://gsa.github.io/auctions_api/static/css/style.css">
+  <link rel="stylesheet" href="https://gsa.github.io/auctions_api/static/css/normalize.css">
+  <link rel="stylesheet" href="https://gsa.github.io/auctions_api/static/css/style.css">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!--[if lt IE 9]>
   <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <!--[if IE]>
-  <link rel="stylesheet" href="http://gsa.github.io/auctions_api/static/css/for-ie-only.css">
+  <link rel="stylesheet" href="https://gsa.github.io/auctions_api/static/css/for-ie-only.css">
   <![endif]-->
 </head>
 <body>
@@ -41,8 +41,8 @@
         {% include footer.html %}
       </div>
     </footer>
-  <script src="http://gsa.github.io/auctions_api/static/js/docs.min.js"></script>
-  <script type="text/javascript" src="http://gsa.github.io/auctions_api/static/js/expandables.js"></script>
+  <script src="https://gsa.github.io/auctions_api/static/js/docs.min.js"></script>
+  <script type="text/javascript" src="https://gsa.github.io/auctions_api/static/js/expandables.js"></script>
 	{% if page.script %}
 		<script type="text/javascript">
 			{{ page.script }}

--- a/static/api_docs/api_docs.json
+++ b/static/api_docs/api_docs.json
@@ -1,7 +1,7 @@
 {
 	  "apiVersion": "1.0.0",
 		"swaggerVersion": "1.2",
-		"basePath": "http://gsa.github.io/sam_api/static/api_docs",
+		"basePath": "https://gsa.github.io/sam_api/static/api_docs",
 		"apis": [
 			{
 				"path": "/sam_swagger.json",


### PR DESCRIPTION
When you load the documentation site over HTTPS (https://gsa.github.io/auctions_api/), the stylesheets and javascript files don't load (since they're being loaded over http), so you end up on an unstyled, and not fully functional site:

![HTTPS screenshot](https://user-images.githubusercontent.com/12112/28427675-35371ff8-6d34-11e7-9984-2c67aac5716a.png)

I believe this pull request should fix it by updating the few hard-coded `http://` references to stylesheets/javascripts to `https://` (which will also be fine if accessed over http).

(I noticed this, because we're currently linking to the HTTPS version of the site on this [api.data.gov docs page](https://api.data.gov/docs/gsa/). We can also update the link on our end to be HTTP, but it seems like it would be preferable to get this working over HTTPS.)